### PR TITLE
Add af-south-1 region

### DIFF
--- a/build.js
+++ b/build.js
@@ -7,6 +7,7 @@ let regionSet = [
   "us-east-1",
   "us-west-1",
   "us-west-2",
+  "af-south-1",
   "ap-east-1",
   "ap-south-1",
   "ap-northeast-2",

--- a/lib/CreateIamUser.js
+++ b/lib/CreateIamUser.js
@@ -7,6 +7,7 @@ let regionSet = [
   "us-east-1",
   "us-west-1",
   "us-west-2",
+  "af-south-1",
   "ap-east-1",
   "ap-south-1",
   "ap-northeast-2",


### PR DESCRIPTION
The `af-south-1` region for the newly added Africa (Cape Town) was missing.